### PR TITLE
SM-2289: Remove ActiveMQ fix in quickstart guide from SM-2269

### DIFF
--- a/src/main/webapp/quickstart/activemq.conf
+++ b/src/main/webapp/quickstart/activemq.conf
@@ -6,14 +6,6 @@ h2. Our scenario
 
 In this scenario, we also want to move files between directories.  Instead of logging the move directly, we are going to send an event JMS message onto a queue.  Afterwards, we will create a second Camel route to receive the events and log them.
 
-h2. Before we start
-
-First, we have to install an optional feature to allow Camel send and receive JMS messages.  We'll talk about optional features a bit more in the next page of this quickstart guide, but for now, just run the following command in the console.
-
-{pygmentize:lang=text}
-karaf@root> features:install camel-jms
-{pygmentize}
-
 h2. Moving files and sending event messages
 The first Blueprint XML file we'll create contains a Camel route that moves the files from {{activemq/input}} to the {{activemq/output}} directory.  Afterwards, it will generate an event message and send that to an ActiveMQ queue called {{events}}.
 
@@ -39,13 +31,6 @@ The first Blueprint XML file we'll create contains a Camel route that moves the 
         <to uri="activemq://events" />
       </route>
     </camelContext>
-
-    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-        <property name="brokerURL" value="tcp://localhost:61616"/>
-    	<property name="userName" value="smx"/>
-    	<property name="password" value="smx"/>
-    </bean>
-
 </blueprint>
 {pygmentize}
 
@@ -69,13 +54,6 @@ After deploying the first XML file, you're obviously not seeing any events being
         <to uri="log:events"/>
       </route>
     </camelContext>
-
-    <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-        <property name="brokerURL" value="tcp://localhost:61616"/>
-    	<property name="userName" value="smx"/>
-    	<property name="password" value="smx"/>
-    </bean>
-
 </blueprint>
 {pygmentize}
 


### PR DESCRIPTION
Just a reversed the previous commit after testing the new quickstart guide on the 5.0.1 release. 
