### PR TITLE
Replace osgi with bundle

### DIFF
--- a/src/main/webapp/camel/troubleshooting.conf
+++ b/src/main/webapp/camel/troubleshooting.conf
@@ -5,6 +5,6 @@ This usually means that your route is trying to use a component that hasn't been
 
 Solution:
 # install the additional component
-# restart the bundle using the {{osg:restart <bundle id>}} command - you can find the bundle id for your route in the output of the {{osgi:list}} command
+# restart the bundle using the {{bundle:restart <bundle id>}} command - you can find the bundle id for your route in the output of the {{bundle:list}} command
 
 Refer to [Installing additional components|/users-guide/camel/installing-components] for more information about installing additional components.

--- a/src/main/webapp/quickstart/activemq.conf
+++ b/src/main/webapp/quickstart/activemq.conf
@@ -34,7 +34,7 @@ The first Blueprint XML file we'll create contains a Camel route that moves the 
 </blueprint>
 {pygmentize}
 
-Save this file in ServiceMix' {{deploy}} folder and use {{osgi:list}} to check on the bundle status as you did with the simple Camel example.  You should now be able to put files in the {{activemq/input}} directory and see them being moved to {{activemq/output}}.
+Save this file in ServiceMix' {{deploy}} folder and use {{bundle:list}} to check on the bundle status as you did with the simple Camel example.  You should now be able to put files in the {{activemq/input}} directory and see them being moved to {{activemq/output}}.
 
 h2. Receiving the event messages
 After deploying the first XML file, you're obviously not seeing any events being logged yet.  The event messages are sent to an ActiveMQ queue, but there's nobody to receive the events yet.  Let's change that now by creating a second Blueprint XML file.

--- a/src/main/webapp/quickstart/camel.conf
+++ b/src/main/webapp/quickstart/camel.conf
@@ -37,7 +37,7 @@ If you do a {{log:display}} in the shell, you will also see the log output for e
 
 h2. Using the shell to manage the route
 
-Using {{osgi:list}}, you'll notice that your XML file has been transformed into a bundle and that the Blueprint container has been created to start your Camel route.
+Using {{bundle:list}}, you'll notice that your XML file has been transformed into a bundle and that the Blueprint container has been created to start your Camel route.
 
 !/quickstart/images/camel-sample-deploy.png!
 
@@ -45,12 +45,12 @@ From this output, you also learn that the bundle id for your XML file is 200.  T
 
 First, stop the route with
 {pygmentize:lang=text}
-karaf@root> osgi:stop 200
+karaf@root> bundle:stop 200
 {pygmentize}
 
 The route is no longer active, so any files you copy into the {{orders/input}} folder will remain there for now.  As soon as you restart the route, the pending files will get moving again.
 
 {pygmentize:lang=text}
-karaf@root> osgi:start 200
+karaf@root> bundle:start 200
 {pygmentize}
 

--- a/src/main/webapp/quickstart/console.conf
+++ b/src/main/webapp/quickstart/console.conf
@@ -6,10 +6,10 @@ h2. Working with bundles
 
 When ServiceMix is first started, a whole set of bundles providing the core features for the product are being installed.  Let's use the command console to find out more about them...
 
-The {{osgi:list}} command can be used to get a list of all bundles currently installed.  Enter this
+The {{bundle:list}} command can be used to get a list of all bundles currently installed.  Enter this
 
 {pygmentize:lang=text}
-karaf@root> osgi:list
+karaf@root> bundle:list
 {pygmentize}
 
 This is what the output looks like if you run this on your ServiceMix instance.
@@ -26,7 +26,7 @@ For every bundle, you see:
 If you're looking for something specific in the list, you can use unix-like pipes and utilities to help you.  An example: to look for all Camel related bundles...
 
 {pygmentize:lang=text}
-karaf@root> osgi:list | grep camel
+karaf@root> bundle:list | grep camel
 {pygmentize}
 
 !/quickstart/images/osgi-list-pipegrep.png|title=osgi:list!


### PR DESCRIPTION
Since Karaf 3.0 the command `osgi` is replaced by `bundle`.

NOTE: There are two osgi references left in
src/main/webapp/quickstart/console.conf.
But they refer to screenshot which I can't replace because I don't have the OS
required to match the others images.
